### PR TITLE
Apply database-schema SVN r6182-r6195 updates

### DIFF
--- a/branches/git/createdb.sql
+++ b/branches/git/createdb.sql
@@ -60,12 +60,6 @@ create table ports_check
 
 create index ports_check_category_id on ports_check (category_id);
 
-create table daily_refreshes
-(
-    refresh_date               date                  not null,
-    primary key (refresh_date)
-);
-
 create table graphs
 (
     id                         serial                not null,

--- a/branches/git/permissions.sql
+++ b/branches/git/permissions.sql
@@ -203,8 +203,6 @@ grant update                         on watch_notice_log_id_seq        to group 
 grant ALL on ports_check           to group commits;
 grant update on ports_check_id_seq to group commits;
 
-grant select, insert, delete         on daily_refreshes                to group commits;
-
 grant select                         on daily_stats                    to group commits;
 grant insert                         on daily_stats_data               to group commits;
 grant update                         on daily_stats_data_seq           to group commits;

--- a/branches/git/ri.txt
+++ b/branches/git/ri.txt
@@ -1242,9 +1242,17 @@ CREATE OR REPLACE FUNCTION package_notifications_delete() RETURNS TRIGGER AS $$
    BEGIN
         -- by definition, this is a delete
 
-        insert into package_notifications(abi_id, package_set, port_id, action, version_previous)
-        values (OLD.abi_id, OLD.package_set, OLD.port_id, 'delete', OLD.package_version)
-        ON CONFLICT ON CONSTRAINT package_notifications_abi_set_port_idx DO NOTHING;
+	if ( new.abi_id is NOT null) then
+		--
+		-- if new.abi_id is null, the ABI has been deleted and
+		-- inserting into package_notifications will result in an
+		-- error, such as: Key (abi_id)=(24) is not present in table "abi".
+		-- see https://github.com/FreshPorts/freshports/issues/642
+		--
+	        insert into package_notifications(abi_id, package_set, port_id, action, version_previous)
+        	values (OLD.abi_id, OLD.package_set, OLD.port_id, 'delete', OLD.package_version)
+	        ON CONFLICT ON CONSTRAINT package_notifications_abi_set_port_idx DO NOTHING;
+	end if;
 
         RETURN OLD;
    END

--- a/branches/git/sp.txt
+++ b/branches/git/sp.txt
@@ -1038,44 +1038,6 @@ CREATE OR REPLACE FUNCTION SystemTimeAdjust() returns interval AS $$
 $$ LANGUAGE 'sql' immutable;
 
 
-CREATE OR REPLACE FUNCTION DailySummaryDateAdd(date) returns int8 AS $$
-	DECLARE
-	        DateToAdd	ALIAS for $1;
-
-		RC		int8;
-
-	BEGIN
-		INSERT INTO daily_refreshes
-		SELECT DateToAdd as refresh_date
-		 WHERE NOT EXISTS (
-		           SELECT refresh_date
-		             FROM daily_refreshes
-		            WHERE refresh_date = DateToAdd);
-
-		GET DIAGNOSTICS RC = ROW_COUNT;
-
-		RETURN RC;
-	END
-$$ LANGUAGE 'plpgsql';
-
-
-
-CREATE OR REPLACE FUNCTION DailySummaryDateRemove(date) returns int8 AS $$
-	DECLARE
-        DateToDelete	ALIAS for $1;
-
-	RowCount    	int8;
-
-	BEGIN
-		DELETE FROM Daily_Refreshes
-		 WHERE Refresh_Date = DateToDelete;
-
-		GET DIAGNOSTICS RowCount = ROW_COUNT;
-
-		RETURN RowCount;
-	END
-$$ LANGUAGE 'plpgsql';
-
 
 CREATE OR REPLACE FUNCTION DailyStatsCaculate() returns int8 AS $$
 	DECLARE

--- a/branches/git/updates-2025-08-01-vuxml_import.sql
+++ b/branches/git/updates-2025-08-01-vuxml_import.sql
@@ -1,0 +1,82 @@
+-- re https://news.freshports.org/2025/07/30/how-freshports-processes-vuxml-entries/
+--    https://github.com/FreshPorts/freshports/issues/633
+--
+-- Table: public.vuxml_import
+
+-- DROP TABLE IF EXISTS public.vuxml_import;
+
+CREATE TABLE IF NOT EXISTS public.vuxml_import
+(
+    vid text COLLATE pg_catalog."default" NOT NULL,
+    checksum text COLLATE pg_catalog."default" NOT NULL,
+    CONSTRAINT vuxml_import_vid PRIMARY KEY (vid)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.vuxml_import
+    OWNER to postgres;
+
+REVOKE ALL ON TABLE public.vuxml_import FROM commits;
+REVOKE ALL ON TABLE public.vuxml_import FROM rsyncer;
+
+GRANT INSERT, DELETE, SELECT, UPDATE, TRUNCATE ON TABLE public.vuxml_import TO commits;
+
+GRANT ALL ON TABLE public.vuxml_import TO postgres;
+
+GRANT SELECT ON TABLE public.vuxml_import TO rsyncer;
+
+-- DROP INDEX IF EXISTS public.vuxml_import_vid;
+
+CREATE INDEX IF NOT EXISTS vuxml_import_vid
+    ON public.vuxml_import USING btree
+    (vid COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+
+grant truncate on vuxml_import to commits;
+
+-- delete the deleted vids.
+
+CREATE OR REPLACE FUNCTION DeleteMissingVuxml() returns int4 AS $$
+DECLARE
+    RowCount    int8;
+
+BEGIN
+
+    -- if it's not in vuxml_import, remove it from vuxml
+
+    WITH deleted_vids AS (
+    SELECT V.vid, V.checksum
+      FROM vuxml V
+    LEFT OUTER JOIN vuxml_import vi
+    ON V.vid = vi.vid
+    WHERE vi.vid IS NULL
+    )
+    DELETE from vuxml V
+     USING deleted_vids as DV
+     WHERE V.vid = DV.vid;
+
+    GET DIAGNOSTICS RowCount = ROW_COUNT;
+    
+    RETURN RowCount;
+END
+$$ LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION GetListOfVulnsForUpdate() returns SETOF text AS $$
+
+-- return a list of vid for updating
+
+SELECT vi.vid
+  FROM vuxml_import vi
+LEFT OUTER JOIN vuxml
+ON vuxml.vid = vi.vid
+WHERE vuxml.checksum <> vi.checksum
+union
+SELECT vi.vid
+  FROM vuxml_import vi
+LEFT OUTER JOIN vuxml
+ON vuxml.vid = vi.vid
+WHERE vuxml.vid IS NULL;
+
+$$ LANGUAGE SQL STABLE;

--- a/branches/git/updates-2025-08-27-use_rc_subr.sql
+++ b/branches/git/updates-2025-08-27-use_rc_subr.sql
@@ -1,0 +1,6 @@
+-- re https://github.com/FreshPorts/freshports/issues/637
+
+ALTER TABLE IF EXISTS public.ports
+    ADD COLUMN use_rc_subr text;
+    
+    


### PR DESCRIPTION
Source SVN repository: freshports-1 UUID 46e82423-29d8-e211-989e-002590a4cdd4

Includes SVN revisions: r6182, r6183, r6184, r6185, r6186, r6188, r6195.

This applies the missing database-schema/branches/git content from the local SVN repository through r6195 while preserving the existing SVN-style repository layout.

Validation performed:
- Exported database-schema/branches/git at r6195 from the local SVN repository.
- Applied the export to branches/git in this repository.
- Verified the Git branch content matched the SVN export with diff -qr before committing.

Note: conversion of SVN tag directories to real Git tags is intentionally left for a separate cleanup phase.